### PR TITLE
Revert to 2.1.0 version of path-exists

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "hat": "0.0.3",
     "mkdirp": "^0.5.1",
-    "path-exists": "^3.0.0",
+    "path-exists": "2.1.0",
     "random-access-file": "^1.0.1",
     "rimraf": "^2.4.2",
     "run-parallel": "^1.1.2",


### PR DESCRIPTION
The latest version of path-exists (v3.0.0) has started using ES2015 javascript features which break on older versions of Node.

Not all users can upgrade to the later versions of node that supports ES2015 javascript which is now used in path-exists. Please can you consider going back to the previous version.