### PR TITLE
Use object shorthand for properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,10 +94,10 @@ function Storage (chunkLength, opts) {
         if (!self.chunkMap[p]) self.chunkMap[p] = []
 
         self.chunkMap[p].push({
-          from: from,
-          to: to,
-          offset: offset,
-          file: file
+          from,
+          to,
+          offset,
+          file
         })
       }
     })


### PR DESCRIPTION
This rule is on its way into the latest Standard ☺️ 

ref: https://github.com/standard/eslint-config-standard/pull/166

Compatibility: This syntax is supported on Node.js >=4, this module supports >=10 ✅ 